### PR TITLE
Fixed Fragment Back Stack Management

### DIFF
--- a/app/src/main/java/nyc/c4q/ashiquechowdhury/auxx/joinandcreate/PlaylistActivity.java
+++ b/app/src/main/java/nyc/c4q/ashiquechowdhury/auxx/joinandcreate/PlaylistActivity.java
@@ -26,14 +26,16 @@ public class PlaylistActivity extends AppCompatActivity implements
         SpotifyPlayer.NotificationCallback, ConnectionStateCallback, Listener, Player.OperationCallback {
 
     SlidingUpPanelLayout slidingPanel;
+    private FragmentManager fragmentManager;
+    private FragmentTransaction fragmentTransaction;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_playlist_container);
 
-        FragmentManager fragmentManager = getSupportFragmentManager();
-        FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+        fragmentManager = getSupportFragmentManager();
+        fragmentTransaction = fragmentManager.beginTransaction();
         fragmentTransaction
                 .replace(R.id.playlist_maincontent_frame, new PlaylistFragment())
                 .replace(R.id.playlist_panelcontent_frame, new MasterMusicPlayerControlsFragment())
@@ -138,5 +140,20 @@ public class PlaylistActivity extends AppCompatActivity implements
     protected void onDestroy() {
         Spotify.destroyPlayer(SpotifyUtil.getInstance().spotifyPlayer);
         super.onDestroy();
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        fragmentManager.addOnBackStackChangedListener(new FragmentManager.OnBackStackChangedListener() {
+            @Override
+            public void onBackStackChanged() {
+                if (fragmentManager.getBackStackEntryCount() == 0) {
+                    finish();
+                } else {
+                    fragmentManager.popBackStack();
+                }
+            }
+        });
     }
 }

--- a/app/src/main/java/nyc/c4q/ashiquechowdhury/auxx/joinandcreate/PlaylistFragment.java
+++ b/app/src/main/java/nyc/c4q/ashiquechowdhury/auxx/joinandcreate/PlaylistFragment.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -28,6 +30,8 @@ import static android.R.id.message;
 public class PlaylistFragment extends Fragment implements
         SpotifyPlayer.NotificationCallback, ConnectionStateCallback, Player.OperationCallback {
 
+
+    private static final String FRAGMENT_TAG = PlaylistFragment.class.getSimpleName();
     RecyclerView recyclerView;
     SpotifyUtil spotify;
 
@@ -58,11 +62,15 @@ public class PlaylistFragment extends Fragment implements
         floatingSearchBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                getActivity().getSupportFragmentManager().beginTransaction().replace(R.id.playlist_maincontent_frame, new SearchFragment()).commit();
+                FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
+                FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+                fragmentTransaction
+                        .replace(R.id.playlist_maincontent_frame, new SearchFragment())
+                        .addToBackStack(FRAGMENT_TAG)
+                        .commit();
             }
         });
     }
-
 
     @Override
     public void onLoggedIn() {


### PR DESCRIPTION
-Fixed navigation between playlist fragment and search fragment
-If in search fragment, and back is pressed, will navigate back to playlist fragment and not to the ChooseRoom Activity